### PR TITLE
Add Jest testing infrastructure for API and endpoint tests

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -1,0 +1,25 @@
+name: API Tests
+
+on:
+  push:
+    paths:
+      - 'API/**'
+  pull_request:
+    paths:
+      - 'API/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: API
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test

--- a/API/.env.test
+++ b/API/.env.test
@@ -1,0 +1,4 @@
+INFLUX_URL=http://localhost
+INFLUX_TOKEN=test-token
+INFLUX_ORG=test-org
+INFLUX_BUCKET=test-bucket

--- a/API/__tests__/getLivePeaks.test.js
+++ b/API/__tests__/getLivePeaks.test.js
@@ -1,0 +1,40 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('GET /api/getLivePeaks', () => {
+  test('returns latest peak', async () => {
+    const rows = [
+      { _time: 't1', _field: 'peakX', _value: 1 },
+      { _time: 't1', _field: 'peakY', _value: 2 },
+      { _time: 't1', _field: 'peakValue', _value: 3 }
+    ];
+    const iterateRows = jest.fn(async function* () {
+      for (const r of rows) {
+        yield { values: null, tableMeta: { toObject: () => r } };
+      }
+    });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app).get('/api/getLivePeaks');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: { time: 't1', peakX: 1, peakY: 2, peakValue: 3 } });
+  });
+
+  test('returns null when no data', async () => {
+    const iterateRows = jest.fn(async function* () {});
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app).get('/api/getLivePeaks');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: null });
+  });
+
+  test('handles errors', async () => {
+    const iterateRows = jest.fn(() => { throw new Error('fail'); });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app).get('/api/getLivePeaks');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Error querying InfluxDB' });
+  });
+});

--- a/API/__tests__/getPeaks.test.js
+++ b/API/__tests__/getPeaks.test.js
@@ -1,0 +1,32 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('GET /api/getPeaks', () => {
+  test('returns last 15 peaks', async () => {
+    const rows = [];
+    for (let i = 0; i < 15; i++) {
+      ['peakX', 'peakY', 'peakValue'].forEach(field => {
+        rows.push({ _time: `t${i}`, _field: field, _value: i });
+      });
+    }
+    const iterateRows = jest.fn(async function* () {
+      for (const r of rows) {
+        yield { values: null, tableMeta: { toObject: () => r } };
+      }
+    });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app).get('/api/getPeaks');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(15);
+  });
+
+  test('handles errors', async () => {
+    const iterateRows = jest.fn(() => { throw new Error('fail'); });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app).get('/api/getPeaks');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Error querying InfluxDB' });
+  });
+});

--- a/API/__tests__/postPeaksRange.test.js
+++ b/API/__tests__/postPeaksRange.test.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('POST /api/postPeaksRange', () => {
+  test('validates body', async () => {
+    const res = await request(app).post('/api/postPeaksRange').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('groups peaks by time', async () => {
+    const rows = [
+      { _time: 't1', _field: 'peakX', _value: 1 },
+      { _time: 't1', _field: 'peakY', _value: 2 },
+      { _time: 't1', _field: 'peakValue', _value: 3 },
+      { _time: 't2', _field: 'peakX', _value: 4 }
+    ];
+    const iterateRows = jest.fn(async function* () {
+      for (const r of rows) {
+        yield { values: null, tableMeta: { toObject: () => r } };
+      }
+    });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app)
+      .post('/api/postPeaksRange')
+      .send({ start: 0, stop: 1 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: [
+      { time: 't1', peakX: 1, peakY: 2, peakValue: 3 },
+      { time: 't2', peakX: 4 }
+    ] });
+  });
+
+  test('handles errors', async () => {
+    const iterateRows = jest.fn(() => { throw new Error('fail'); });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app)
+      .post('/api/postPeaksRange')
+      .send({ start: 0, stop: 1 });
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Error querying InfluxDB' });
+  });
+});

--- a/API/__tests__/sensorRange.get.test.js
+++ b/API/__tests__/sensorRange.get.test.js
@@ -1,0 +1,29 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('GET /api/sensorRange', () => {
+  test('returns oldest and newest timestamps', async () => {
+    const iterateRows = jest.fn()
+      .mockImplementationOnce(async function* () {
+        yield { values: null, tableMeta: { toObject: () => ({ _time: 'old' }) } };
+      })
+      .mockImplementationOnce(async function* () {
+        yield { values: null, tableMeta: { toObject: () => ({ _time: 'new' }) } };
+      });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app).get('/api/sensorRange');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ oldest: 'old', newest: 'new' });
+    expect(iterateRows).toHaveBeenCalledTimes(2);
+  });
+
+  test('handles errors', async () => {
+    const iterateRows = jest.fn(() => { throw new Error('fail'); });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app).get('/api/sensorRange');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Error querying InfluxDB' });
+  });
+});

--- a/API/__tests__/sensorRange.post.test.js
+++ b/API/__tests__/sensorRange.post.test.js
@@ -1,0 +1,36 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('POST /api/sensorRange', () => {
+  test('validates body', async () => {
+    const res = await request(app).post('/api/sensorRange').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('calculates averages', async () => {
+    const iterateRows = jest.fn(async function* () {
+      for (let i = 0; i < 12; i++) {
+        yield { values: null, tableMeta: { toObject: () => ({ _field: 's1', _value: 1, _time: `t${i}` }) } };
+      }
+    });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app)
+      .post('/api/sensorRange')
+      .send({ start: 0, stop: 1 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: { s1: [ { time: 't5', value: 1 }, { time: 't11', value: 1 } ] } });
+  });
+
+  test('handles errors', async () => {
+    const iterateRows = jest.fn(() => { throw new Error('fail'); });
+    app.locals.queryApi = { iterateRows };
+
+    const res = await request(app)
+      .post('/api/sensorRange')
+      .send({ start: 0, stop: 1 });
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Error querying InfluxDB' });
+  });
+});

--- a/API/jest.config.js
+++ b/API/jest.config.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1'
+  },
+  setupFiles: [path.join(__dirname, 'jest.setup.js')]
+};

--- a/API/jest.setup.js
+++ b/API/jest.setup.js
@@ -1,0 +1,2 @@
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env.test') });

--- a/API/package.json
+++ b/API/package.json
@@ -2,9 +2,10 @@
   "name": "auditim-backend",
   "version": "1.0.0",
   "description": "Dies ist das zentrale Code-Repository für unser Software-Engineering-Projekt **audiTim**.",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",
@@ -23,5 +24,10 @@
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "node-fetch": "^2.7.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "jest-environment-node": "^29.7.0"
   }
 }

--- a/API/server.js
+++ b/API/server.js
@@ -1,0 +1,22 @@
+const app = require('./app');
+
+const PORT = process.env.PORT || 3000;
+const server = app.listen(PORT, '0.0.0.0', () => {
+  console.log(`API listening on port ${PORT}`);
+});
+
+const shutdown = async () => {
+  console.log('🛑 Shutting down API service...');
+  try {
+    await app.locals.writeApi.close();
+    console.log('✅ Influx write API closed.');
+  } catch (e) {
+    console.warn('⚠️ Error closing write API:', e.message);
+  }
+  server.close(() => process.exit(0));
+};
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+
+module.exports = server;


### PR DESCRIPTION
## Summary
- set up Jest and Supertest with node test environment
- refactor API into app and server for easier testing
- add CI workflow to run API tests

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: jest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b1ab9715f48321899e2b13980bd149